### PR TITLE
DM-14060: Add patches for PR#79

### DIFF
--- a/patches/0001-Resolve-compilation-errors-with-GCC-6.0.0-r233941.patch
+++ b/patches/0001-Resolve-compilation-errors-with-GCC-6.0.0-r233941.patch
@@ -1,0 +1,48 @@
+From 434c4a4f9459933b6fb291e5e86148a30df97b92 Mon Sep 17 00:00:00 2001
+From: David Abdurachmanov <david.abdurachmanov@gmail.com>
+Date: Wed, 30 Mar 2016 15:40:56 +0200
+Subject: [PATCH 1/2] Resolve compilation errors with GCC 6.0.0 (r233941)
+
+Whitespace around string literal is required.
+
+Signed-off-by: David Abdurachmanov <david.abdurachmanov@gmail.com>
+---
+ src/analyse.cc | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/analyse.cc b/src/analyse.cc
+index 570441a..c725055 100644
+--- a/src/analyse.cc
++++ b/src/analyse.cc
+@@ -4374,8 +4374,8 @@ IgProfAnalyzerApplication::generateFlatReport(ProfileInfo & /* prof */,
+       else
+         puts(",");
+ 
+-      printf("[%d, %d, %d, %"PRId64", %"PRId64", %"PRId64", %"PRId64", "
+-              "%"PRId64", %"PRId64", %"PRId64", ",
++      printf("[%d, %d, %d, %" PRId64 ", %" PRId64 ", %" PRId64 ", %" PRId64 ", "
++              "%" PRId64 ", %" PRId64 ", %" PRId64 ", ",
+                 mainRow.rank(), symbolIndex, fileIndex,
+                 mainRow.SELF, mainRow.CUM, mainRow.KIDS,
+                 mainRow.SELF_ALL[1], mainRow.CUM_ALL[1],
+@@ -4445,7 +4445,7 @@ IgProfAnalyzerApplication::generateFlatReport(ProfileInfo & /* prof */,
+           first = false;
+         else
+           puts(",");
+-        printf("[%d, %d, %"PRId64", %"PRId64", %"PRId64", ",
++        printf("[%d, %d, %" PRId64 ", %" PRId64 ", %" PRId64 ", ",
+                mainRow.rank(), row.rank(),
+                row.SELF_COUNTS, row.SELF_CALLS, row.SELF_PATHS);
+ 
+@@ -4472,7 +4472,7 @@ IgProfAnalyzerApplication::generateFlatReport(ProfileInfo & /* prof */,
+           first = false;
+         else
+           puts(",");
+-        printf("[%d, %d, %"PRId64", %"PRId64", %"PRId64", ",
++        printf("[%d, %d, %" PRId64 ", %" PRId64 ", %" PRId64 ", ",
+                mainRow.rank(), row.rank(),
+                row.SELF_COUNTS, row.SELF_CALLS, row.SELF_PATHS);
+ 
+-- 
+2.16.2
+

--- a/patches/0002-monkeypatch-dl_iterate_phdr-to-avoid-deadlocks.patch
+++ b/patches/0002-monkeypatch-dl_iterate_phdr-to-avoid-deadlocks.patch
@@ -1,0 +1,119 @@
+From a5a56db1663f42dadc4caff0fae0146d0db2dead Mon Sep 17 00:00:00 2001
+From: Paul Price <price@astro.princeton.edu>
+Date: Thu, 15 Mar 2018 23:54:15 -0400
+Subject: [PATCH 2/2] monkeypatch dl_iterate_phdr to avoid deadlocks
+
+dl_iterate_phdr can be called by the program we're profiling (e.g.,
+by libc). When a sample fires in while dl_iterate_phdr has locked
+its mutex, we run our own dl_iterate_phdr that then attempts to
+lock the same mutex, resulting in a deadlock. In order to prevent
+that, we override the definition of dl_iterate_phdr and protect
+the original definition so it cannot be called within the same
+thread if it's already being called.
+
+Attempts at doing this with LIBHOOK and DUAL_HOOK were unsuccessful.
+---
+ src/profile-perf.cc | 54 +++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 54 insertions(+)
+
+diff --git a/src/profile-perf.cc b/src/profile-perf.cc
+index f32d037..d943206 100644
+--- a/src/profile-perf.cc
++++ b/src/profile-perf.cc
+@@ -7,11 +7,16 @@
+ #include <cstring>
+ #include <signal.h>
+ #include <sys/time.h>
++#include <link.h>
++#include <dlfcn.h>
++#include <pthread.h>
+ 
+ #ifdef __APPLE__
+ typedef sig_t sighandler_t;
+ #endif
+ 
++typedef int(*dl_iterate_callback)(struct dl_phdr_info *, size_t , void *);
++
+ // -------------------------------------------------------------------
+ // Traps for this profiler module
+ LIBHOOK(0, int, dofork, _main, (), (), "fork", 0, 0)
+@@ -24,6 +29,7 @@ LIBHOOK(3, int, dosigaction, _main,
+         (int signum, const struct sigaction *act, struct sigaction *oact),
+         (signum, act, oact),
+         "sigaction", 0, 0)
++
+ //Looks like the dynamic loader invokes `close` on ARM, which leads to a
+ //segfault in the doclose / dofclose hooks. For the moment I just exclude the
+ //hook, however given it is actually used to protect an output corruption in
+@@ -39,6 +45,7 @@ static bool                     s_initialized   = false;
+ static bool                     s_keep          = false;
+ static int                      s_signal        = SIGPROF;
+ static int                      s_itimer        = ITIMER_PROF;
++HIDDEN pthread_key_t            dl_iterate_key;
+ 
+ /** Convert timeval to seconds. */
+ static inline double tv2sec(const timeval &tv)
+@@ -124,6 +131,8 @@ initialize(void)
+   bool          enable = false;
+   bool          enable_on_init = true;
+ 
++  pthread_key_create(&dl_iterate_key, free);
++
+   while (options && *options)
+   {
+     while (*options == ' ' || *options == ',')
+@@ -394,6 +403,51 @@ dosystem(IgHook::SafeData<igprof_dosystem_t> &hook, const char *cmd)
+   return ret;
+ }
+ 
++namespace {
++
++    // RAII for 'inUse'; used by dodl_iterate_phdr
++    struct inUseRaii {
++        inUseRaii(bool &inUse_) : inUse(inUse_) { inUse = true; }
++        ~inUseRaii() { inUse = false; }
++        bool & inUse;
++    };
++
++    // Holder for original dl_iterate_phdr function
++    typedef int(*dl_iterate_fn)(dl_iterate_callback, void *);
++    dl_iterate_fn dl_iterate_phdr_orig() {
++        static dl_iterate_fn orig = reinterpret_cast<dl_iterate_fn>(dlsym(RTLD_NEXT, "dl_iterate_phdr"));
++        return orig;
++    }
++
++}
++
++// Monkey-patched dl_iterate_phdr
++//
++// dl_iterate_phdr may be used legitimately by the target program
++// (in particular, by libc during exception handling), in which
++// case it locks a mutex. If our sample fires when that mutex
++// is locked, our own call to dl_iterate_phdr will result in a
++// deadlock. We therefore allow only one dl_iterate_phdr in flight
++// at a time. This may result in some lost samples, but it allows
++// the profiled program to complete.
++extern "C"
++int dl_iterate_phdr(dl_iterate_callback callback, void *data)
++{
++    bool *inUse = reinterpret_cast<bool*>(pthread_getspecific(dl_iterate_key));
++    if (!inUse) {
++        inUse = reinterpret_cast<bool*>(malloc(sizeof(bool)));
++        pthread_setspecific(dl_iterate_key, inUse);
++        *inUse = false;
++    }
++    if (*inUse) {
++        igprof_debug("Prevented potential deadlock in dl_iterate_phdr\n");
++        return 0;
++    }
++    inUseRaii raii(*inUse);
++    return dl_iterate_phdr_orig()(callback, data);
++}
++
++
+ #ifndef __arm__
+ // If the profiled program closes stderr stream the igprof_debug got to be
+ // disabled by changing the value of s_igprof_stderrOpen (declared in profile.h
+-- 
+2.16.2
+


### PR DESCRIPTION
PR#79 claims to resolve deadlocks when running igprof. Without this fix,
igprof can be near useless, as it can be impossible to get it to complete
a long-running process. However, the admins are yet to merge this to master
and it's not clear when they will do so. Therefore, I pulled the patches
out of git and plugged them into the patches directory for application
at build time.

https://github.com/igprof/igprof/pull/79